### PR TITLE
Update utils.Promise for Pouchdb 6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ after_failure:
 env:
   matrix:
   - COMMAND=test
-  - CLIENT=selenium:firefox COMMAND=test
   - CLIENT=selenium:phantomjs COMMAND=test
   - COMMAND=coverage
   - COMMAND=report-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
   - "8"
 script: npm run $COMMAND
 before_script:
-  - export FIREFOX_BIN=$(which firefox)
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - "sleep 5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "8"
 script: npm run $COMMAND
 before_script:
+  - export FIREFOX_BIN=$(which firefox)
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - "sleep 5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - couchdb
 
 node_js:
-  - "0.10"
+  - "8"
 script: npm run $COMMAND
 before_script:
   - "export DISPLAY=:99.0"

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -13,6 +13,8 @@ var testTimeout = 30 * 60 * 1000;
 var username = process.env.SAUCE_USERNAME;
 var accessKey = process.env.SAUCE_ACCESS_KEY;
 
+var FIREFOX_BIN = process.env.FIREFOX_BIN;
+
 // process.env.CLIENT is a colon seperated list of
 // (saucelabs|selenium):browserName:browserVerion:platform
 var tmp = (process.env.CLIENT || 'selenium:firefox').split(':');
@@ -129,6 +131,10 @@ function startTest() {
     'idle-timeout': 599,
     'tunnel-identifier': tunnelId
   };
+
+  if (FIREFOX_BIN) {
+    opts.firefox_binary = FIREFOX_BIN;
+  }
 
   sauceClient.init(opts).get(testUrl, function () {
 

--- a/bin/test-browser.js
+++ b/bin/test-browser.js
@@ -13,8 +13,6 @@ var testTimeout = 30 * 60 * 1000;
 var username = process.env.SAUCE_USERNAME;
 var accessKey = process.env.SAUCE_ACCESS_KEY;
 
-var FIREFOX_BIN = process.env.FIREFOX_BIN;
-
 // process.env.CLIENT is a colon seperated list of
 // (saucelabs|selenium):browserName:browserVerion:platform
 var tmp = (process.env.CLIENT || 'selenium:firefox').split(':');
@@ -131,10 +129,6 @@ function startTest() {
     'idle-timeout': 599,
     'tunnel-identifier': tunnelId
   };
-
-  if (FIREFOX_BIN) {
-    opts.firefox_binary = FIREFOX_BIN;
-  }
 
   sauceClient.init(opts).get(testUrl, function () {
 

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "report-coverage": "npm test --coverage && istanbul check-coverage && istanbul-coveralls --no-rm"
   },
   "dependencies": {
-    "lie": "^2.6.0",
-    "inherits": "~2.0.1",
-    "argsarray": "0.0.1"
+    "argsarray": "0.0.1",
+    "inherits": "^2.0.3",
+    "native-or-lie": "^1.0.2"
   },
   "devDependencies": {
     "bluebird": "^1.0.7",
@@ -52,7 +52,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "~1.18",
     "phantomjs": "^1.9.7-5",
-    "pouchdb": "^4.0.0",
+    "pouchdb": "^6.3.4",
     "request": "^2.36.0",
     "sauce-connect-launcher": "^0.4.2",
     "selenium-standalone": "3.0.2",

--- a/pouch-utils.js
+++ b/pouch-utils.js
@@ -1,12 +1,6 @@
 'use strict';
 
-var Promise;
-/* istanbul ignore next */
-if (typeof window !== 'undefined' && window.PouchDB) {
-  Promise = window.PouchDB.utils.Promise;
-} else {
-  Promise = typeof global.Promise === 'function' ? global.Promise : require('lie');
-}
+var Promise = require('native-or-lie');
 /* istanbul ignore next */
 exports.once = function (fun) {
   var called = false;

--- a/test/test.js
+++ b/test/test.js
@@ -500,7 +500,7 @@ function tests(dbName, dbType) {
         });
       }
 
-      return PouchDB.utils.Promise.all(tasks.map(function (task) {
+      return Promise.all(tasks.map(function (task) {
         return cache(task.key, task.value);
       }));
     });


### PR DESCRIPTION
Fixes #7. PouchDB dropped support for `PouchDB.utils.Promise`, so I'm using [native-or-lie](https://www.npmjs.com/package/native-or-lie) instead.